### PR TITLE
Switch Windows build from --onefile to --standalone to avoid CrowdStr…

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build with Nuitka
         # Note: Using --standalone with --macos-create-app-bundle to create a proper .app bundle
-        # (macOS convention), unlike Windows which uses --onefile for a single .exe
+        # Both Windows and macOS use --standalone to avoid CrowdStrike blocking issues
         run: |
           uv run python -m nuitka \
             --standalone \

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build with Nuitka
         run: |
           uv run python -m nuitka `
-            --onefile `
+            --standalone `
             --enable-plugin=pyside6 `
             --windows-console-mode=disable `
             --assume-yes-for-downloads `
@@ -75,21 +75,26 @@ jobs:
 
           & signtool sign /f $certPath /p $env:WINDOWS_SIGN_CERT_PASSWORD `
             /tr http://timestamp.digicert.com /td sha256 /fd sha256 `
-            LeidenToEpiDoc.exe
+            leiden-epidoc.dist\LeidenToEpiDoc.exe
 
           Remove-Item $certPath
+
+      - name: Create ZIP of standalone distribution
+        shell: pwsh
+        run: |
+          Compress-Archive -Path leiden-epidoc.dist\* -DestinationPath LeidenToEpiDoc-Windows.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: LeidenToEpiDoc-Windows
-          path: LeidenToEpiDoc.exe
+          path: LeidenToEpiDoc-Windows.zip
           if-no-files-found: error
 
       - name: Upload to Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: LeidenToEpiDoc.exe
+          files: LeidenToEpiDoc-Windows.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…ike blocking (#88)

* Initial plan

* Change Windows build from --onefile to --standalone to avoid CrowdStrike blocking

- Switch Nuitka from --onefile to --standalone mode
- Sign the exe within the standalone dist directory
- Zip the standalone distribution for artifact/release upload
- Update macOS workflow comment referencing old Windows approach



---------